### PR TITLE
fix: set access modifier on suggestions variable

### DIFF
--- a/src/app/ngx-autocomplete/ngx-autocomplete.component.ts
+++ b/src/app/ngx-autocomplete/ngx-autocomplete.component.ts
@@ -38,7 +38,7 @@ export class NgxAutocompleteComponent implements OnInit, ControlValueAccessor, A
   @Output() selected = new EventEmitter<string>();
   private innerValue: string = '';
   private doQuery: boolean = true;
-  private suggestions: any[];
+  public suggestions: any[];
   private activeSuggestionIndex: number = 0;
   private ngUnsubscribe = new Subject();
 


### PR DESCRIPTION
Needs to be public as it is used in the .html template, otherwise --aot would fail

FIxes: https://github.com/arpadvas/ngx-autocomplete/issues/1